### PR TITLE
Add missing fetch_get_json import

### DIFF
--- a/src/ApiSubscriptionManager.js
+++ b/src/ApiSubscriptionManager.js
@@ -1,4 +1,5 @@
 import global_store from "./GlobalStore.js";
+import {fetch_get_json} from "./Fetch.js";
 
 
 const subscription_interval_map = {}


### PR DESCRIPTION
## Summary
- import fetch_get_json in ApiSubscriptionManager

## Testing
- `node -e "import('./src/ApiSubscriptionManager.js').catch(e=>console.error(e.message))"` *(fails because modules expect browser `window` object)*